### PR TITLE
Prepare 5.6.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
     <groupId>edu.stanford.protege</groupId>
     <artifactId>protege-distribution</artifactId>
     <packaging>pom</packaging>
-    <version>5.6.0-beta-1-SNAPSHOT</version>
+    <version>5.6.0-beta-2-SNAPSHOT</version>
 
     <properties>
         <!--
         The version of Protege that we are targeting.  We set this to our project version.  The two should be in sync.
         Note that we declare the oss-sonatype snapshot repository so that we can work with snapshots.
         -->
-        <protege.version>5.6.0-beta-1-SNAPSHOT</protege.version>
+        <protege.version>5.6.0-beta-2-SNAPSHOT</protege.version>
 
         <!--
         The directory name for a distribution.  This is the directory that a user copies to the location

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,18 @@
             <version>2.0.10</version>
         </dependency>
 
+        <dependency>
+            <groupId>au.csiro</groupId>
+            <artifactId>elk-protege</artifactId>
+            <version>0.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.liveontologies</groupId>
+            <artifactId>puli</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
     <groupId>edu.stanford.protege</groupId>
     <artifactId>protege-distribution</artifactId>
     <packaging>pom</packaging>
-    <version>5.6.0</version>
+    <version>5.6.0-beta-1-SNAPSHOT</version>
 
     <properties>
         <!--
         The version of Protege that we are targeting.  We set this to our project version.  The two should be in sync.
         Note that we declare the oss-sonatype snapshot repository so that we can work with snapshots.
         -->
-        <protege.version>5.6.0</protege.version>
+        <protege.version>5.6.0-beta-1-SNAPSHOT</protege.version>
 
         <!--
         The directory name for a distribution.  This is the directory that a user copies to the location

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/${os-x.directory}/${protege.directory}/Protégé.app/Contents/Java/plugins
+                            <outputDirectory>${project.build.directory}/${os-x.directory}/${protege.directory}/Protégé.app/Contents/plugins
                             </outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>


### PR DESCRIPTION
This PR

* adds the ELK reasoner to the bundled plugins;
* updates the location of the `plugins` directory on macOS, to reflect changes in protege-5.6.0;
* temporarily set version number to 5.6.0-beta-2.