### PR TITLE
Upgrade ELK to v0.6.0, puli no longer required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,15 +186,9 @@
         </dependency>
 
         <dependency>
-            <groupId>au.csiro</groupId>
+            <groupId>io.github.liveontologies</groupId>
             <artifactId>elk-protege</artifactId>
-            <version>0.5.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.liveontologies</groupId>
-            <artifactId>puli</artifactId>
-            <version>0.1.0</version>
+            <version>0.6.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
ELK v0.6.0 was released yesterday:

https://github.com/liveontologies/elk-reasoner/releases/tag/v0.6.0